### PR TITLE
Renaming browser keys to Browser Exam Keys.

### DIFF
--- a/lang/en/quizaccess_safeexambrowser.php
+++ b/lang/en/quizaccess_safeexambrowser.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 
-$string['allowedbrowserkeys'] = 'Allowed browser keys';
-$string['allowedbrowserkeys_help'] = 'In this box you can enter the allowed browser keys for versions of Safe Exam Browser that are permitted to access this quiz. If no keys are entered, then SEB is not required for this quiz.';
+$string['allowedbrowserkeys'] = 'Allowed Browser Exam Keys';
+$string['allowedbrowserkeys_help'] = 'In this box you can enter the allowed Browser Exam Keys for versions of Safe Exam Browser that are permitted to access this quiz. If no keys are entered, then SEB is not required for this quiz.';
 $string['allowedbrowserkeysdistinct'] = 'The keys must all be different.';
 $string['allowedbrowserkeyssyntax'] = 'You must enter the allowed keys one per line. A key should be a 64-character hex string.';
 $string['allowedkeys_adv'] = 'Keys are an advanced setting';


### PR DESCRIPTION
Hi Tim,

You may have to cross-check this with @danschlet, but I think I am not mistaken.

Helps setting up Safe Exam Browser quizzes if the Moodle and SEB strings correspond!

Best,

Luca